### PR TITLE
update macro syntax to be compatible with python3

### DIFF
--- a/Macros/JointCreator.FCMacro
+++ b/Macros/JointCreator.FCMacro
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FreeCAD as App
 import FreeCADGui
 import FreeCAD
@@ -81,10 +82,10 @@ class CreateHingeJointForm(QtGui.QDialog):
     self.close()
 
 def routine1():
-  print 'create!'
+  print('create!')
 
 def routine2():
-  print 'abort!'
+  print('abort!')
 
 class Joint:
   def __init__(self, obj,parent,child):
@@ -123,7 +124,7 @@ if len(selection) == 2:
     ViewProviderJoint(j.ViewObject)
     App.ActiveDocument.recompute() 
   elif form.retStatus==2:
-    print 'abort'
+    print('abort')
 
 else:
-  print "Only support selection of two elements on two different objects"
+  print("Only support selection of two elements on two different objects")

--- a/Macros/sdfExport.FCMacro
+++ b/Macros/sdfExport.FCMacro
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os, sys, Mesh
 
 def float_to_str(f):
@@ -47,7 +48,7 @@ modelCFG.write('  </description>\n')
 modelCFG.write('</model>\n')
 modelCFG.close()
 
-print "writing to file" + projPath+robotName+'.sdf'
+print("writing to file" + projPath+robotName+'.sdf')
 sdfFile = open(projPath+robotName+'.sdf', 'w')
 sdfFile.write('<?xml version=\"1.0\"?>\n')
 sdfFile.write('<sdf version=\"1.5\">\n')
@@ -55,9 +56,9 @@ sdfFile.write('<model name=\"'+robotName+'\">\n')
 
 objs = FreeCAD.ActiveDocument.Objects
 for obj in objs:
-  print obj.Name
+  print(obj.Name)
   if "Joint" in obj.Name:
-    print "Joint: " + obj.Name + " with label " + obj.Label+ " detected!"
+    print("Joint: " + obj.Name + " with label " + obj.Label+ " detected!")
     pos = obj.Shape.Placement
     pos.Base *= 0.001
     sdfFile.write(' <joint name="'+bodyLabelFromObjStr(obj.Parent)+bodyLabelFromObjStr(obj.Child)+'" type="revolute">\n')
@@ -70,7 +71,7 @@ for obj in objs:
     sdfFile.write(' </joint>\n')
 
   if obj.TypeId == 'PartDesign::Body' or obj.TypeId == 'Part::Box':
-    print "Link: " + obj.Name + " with label " + obj.Label+ " detected!"
+    print("Link: " + obj.Name + " with label " + obj.Label+ " detected!")
     name = obj.Label
     mass = obj.Shape.Mass
     inertia = obj.Shape.MatrixOfInertia


### PR DESCRIPTION
Good evening, thanks for provising those macros. I tried running the macros on freecad-daily on ubuntu 18.04 but it uses Python 3.6.8 so I got a syntax error. Hence, I ran 2to3 and added a from __future__ import print_function so that they're now compatible w/ both python 2.7 and python 3. 