### PR TITLE
Migrate "print" function to python3's form

### DIFF
--- a/CreateJoint.py
+++ b/CreateJoint.py
@@ -87,10 +87,10 @@ class CreateHingeJointForm(QtGui.QDialog):
 		self.close()
 
 def routine1():
-	print 'create!'
+	print("create!")
 
 def routine2():
-	print 'abort!'
+	print("abort!")
 
 class Joint:
 	def __init__(self, obj,parent,child):
@@ -120,14 +120,14 @@ class CreateJoint:
 	"""RC_CreateJoint"""
 
 	def GetResources(self):
-		print FreeCAD.getUserAppDataDir()+"Mod" + "/RobotCreator/icons/createJoint.png"
+		print(FreeCAD.getUserAppDataDir()+"Mod" + "/RobotCreator/icons/createJoint.png")
 		return {'Pixmap'  : str(FreeCAD.getUserAppDataDir()+"Mod" + "/RobotCreator/icons/createJoint.png"), # the name of a svg file available in the resources
 			'Accel' : "Shift+j", # a default shortcut (optional)
 			'MenuText': "Create a joint",
 			'ToolTip' : "Create a joint"}
 
 	def Activated(self):
-		print "creating a joint"
+		print("creating a joint")
 
 		selection = Gui.Selection.getSelection()
 		if len(selection) == 2:
@@ -142,9 +142,9 @@ class CreateJoint:
 				ViewProviderJoint(j.ViewObject)
 				App.ActiveDocument.recompute() 
 			elif form.retStatus==2:
-				print 'abort'
+				print("abort!")
 		else:
-			print "Only support selection of two elements on two different objects"
+			print("Only support selection of two elements on two different objects")
 
 	def IsActive(self):
 		"""Here you can define if the command must be active or not (greyed) if certain conditions

--- a/ExportSDF.py
+++ b/ExportSDF.py
@@ -12,7 +12,7 @@ class ExportSDF:
                 'ToolTip' : "Export Robot to SDF"}
 
     def Activated(self):
-	print "Exporting SDF file"
+	print("Exporting SDF file")
 	robotName = "testing"
 
 	sdfFile = open(robotName+'.sdf', 'w')

--- a/GazeboSDFExport.py
+++ b/GazeboSDFExport.py
@@ -36,7 +36,7 @@ class GazeboSDFExport:
 				'ToolTip' : "Exports SDF to Gazebo"}
 
 	def Activated(self):
-		print "Scaling mesh"
+		print("Scaling mesh")
 
 		# you might want to change this to where you want your exported mesh/sdf to be located.
 		robotName = "testing"
@@ -59,9 +59,9 @@ class GazeboSDFExport:
 
 		objs = FreeCAD.ActiveDocument.Objects
 		for obj in objs:
-			print obj.Name
+			print(obj.Name)
 			if "Joint" in obj.Name:
-				print "Joint: " + obj.Name + " with label " + obj.Label+ " detected!"
+				print("Joint: " + obj.Name + " with label " + obj.Label+ " detected!")
 				pos = obj.Shape.Placement
 				pos.Base *= 0.001
 				sdfFile.write(' <joint name="'+bodyLabelFromObjStr(obj.Parent)+bodyLabelFromObjStr(obj.Child)+'" type="revolute">\n')
@@ -74,7 +74,7 @@ class GazeboSDFExport:
 				sdfFile.write(' </joint>\n')
 
 			if obj.TypeId == 'PartDesign::Body' or obj.TypeId == 'Part::Box':
-				print "Link: " + obj.Name + " with label " + obj.Label+ " detected!"
+				print("Link: " + obj.Name + " with label " + obj.Label+ " detected!")
 				name = obj.Label
 				mass = obj.Shape.Mass
 				inertia = obj.Shape.MatrixOfInertia

--- a/GazeboSDFExportStatic.py
+++ b/GazeboSDFExportStatic.py
@@ -36,7 +36,7 @@ class GazeboSDFExportStatic:
 				'ToolTip' : "Exports static SDF to Gazebo"}
 
 	def Activated(self):
-		print "Scaling mesh"
+		print("Scaling mesh")
 
 		# you might want to change this to where you want your exported mesh/sdf to be located.
 		robotName = "testing"
@@ -60,9 +60,9 @@ class GazeboSDFExportStatic:
 
 		objs = FreeCAD.ActiveDocument.Objects
 		for obj in objs:
-			print obj.Name
+			print(obj.Name)
 			if "Joint" in obj.Name:
-				print "Joint: " + obj.Name + " with label " + obj.Label+ " detected!"
+				print("Joint: " + obj.Name + " with label " + obj.Label+ " detected!")
 				pos = obj.Shape.Placement
 				pos.Base *= 0.001
 				sdfFile.write(' <joint name="'+bodyLabelFromObjStr(obj.Parent)+bodyLabelFromObjStr(obj.Child)+'" type="revolute">\n')
@@ -75,7 +75,7 @@ class GazeboSDFExportStatic:
 				sdfFile.write(' </joint>\n')
 
 			if obj.TypeId == 'PartDesign::Body' or obj.TypeId == 'Part::Box':
-				print "Link: " + obj.Name + " with label " + obj.Label+ " detected!"
+				print("Link: " + obj.Name + " with label " + obj.Label+ " detected!")
 				name = obj.Label
 				mass = obj.Shape.Mass
 				inertia = obj.Shape.MatrixOfInertia

--- a/Init.py
+++ b/Init.py
@@ -28,4 +28,4 @@ FreeCAD.addExportType("SDF (*.sdf)","importSDF")
 FreeCAD.addImportType("URDF (*.urdf)","importURDF")
 FreeCAD.addExportType("URDF (*.urdf)","importURDF")
 
-print "Just Initial Stuff!"
+print ("Just Initial Stuff!")

--- a/InitGui.py
+++ b/InitGui.py
@@ -40,7 +40,7 @@ static char * C:\Program Files\FreeCAD 0_15\Mod\Fasteners\wbicon_xpm[] = {
         self.appendToolbar("RobotCreator",self.list) # creates a new toolbar with your commands
         self.appendMenu("My New Menu",self.list) # creates a new menu
         self.appendMenu(["An existing Menu","My submenu"],self.list) # appends a submenu to an existing menu
-	FreeCADGui.addIconPath( '~/.FreeCAD/Mod/RobotCreator/icons' )
+    FreeCADGui.addIconPath("~/.FreeCAD/Mod/RobotCreator/icons")
     def Activated(self):
         "This function is executed when the workbench is activated"
         return

--- a/Macros/JointCreator.FCMacro
+++ b/Macros/JointCreator.FCMacro
@@ -81,10 +81,10 @@ class CreateHingeJointForm(QtGui.QDialog):
     self.close()
 
 def routine1():
-  print 'create!'
+  print("create!")
 
 def routine2():
-  print 'abort!'
+  print("abort!")
 
 class Joint:
   def __init__(self, obj,parent,child):
@@ -123,7 +123,7 @@ if len(selection) == 2:
     ViewProviderJoint(j.ViewObject)
     App.ActiveDocument.recompute() 
   elif form.retStatus==2:
-    print 'abort'
+    print("abort!")
 
 else:
-  print "Only support selection of two elements on two different objects"
+  print("Only support selection of two elements on two different objects")

--- a/Macros/sdfExport.FCMacro
+++ b/Macros/sdfExport.FCMacro
@@ -47,7 +47,7 @@ modelCFG.write('  </description>\n')
 modelCFG.write('</model>\n')
 modelCFG.close()
 
-print "writing to file" + projPath+robotName+'.sdf'
+print("writing to file" + projPath + robotName + ".sdf")
 sdfFile = open(projPath+robotName+'.sdf', 'w')
 sdfFile.write('<?xml version=\"1.0\"?>\n')
 sdfFile.write('<sdf version=\"1.5\">\n')
@@ -55,9 +55,9 @@ sdfFile.write('<model name=\"'+robotName+'\">\n')
 
 objs = FreeCAD.ActiveDocument.Objects
 for obj in objs:
-  print obj.Name
+  print(obj.Name)
   if "Joint" in obj.Name:
-    print "Joint: " + obj.Name + " with label " + obj.Label+ " detected!"
+    print("Joint: " + obj.Name + " with label " + obj.Label+ " detected!")
     pos = obj.Shape.Placement
     pos.Base *= 0.001
     sdfFile.write(' <joint name="'+bodyLabelFromObjStr(obj.Parent)+bodyLabelFromObjStr(obj.Child)+'" type="revolute">\n')
@@ -70,7 +70,7 @@ for obj in objs:
     sdfFile.write(' </joint>\n')
 
   if obj.TypeId == 'PartDesign::Body' or obj.TypeId == 'Part::Box':
-    print "Link: " + obj.Name + " with label " + obj.Label+ " detected!"
+    print("Link: " + obj.Name + " with label " + obj.Label+ " detected!")
     name = obj.Label
     mass = obj.Shape.Mass
     inertia = obj.Shape.MatrixOfInertia


### PR DESCRIPTION
Thanks for making this great workbench. 
However, it cannot execute in FreeCad which is compiled with python3.
It might be better for us to migrate "print" function to python3 form.

In the case of using in python2 and 3, the workbench could require conditional branches which depend on python version. 

Best regard